### PR TITLE
Feat: Change umask of homedir to 077

### DIFF
--- a/usr/share/linuxmuster-linuxclient7/templates/common-session
+++ b/usr/share/linuxmuster-linuxclient7/templates/common-session
@@ -21,7 +21,7 @@ session	[default=1]	pam_permit.so
 session	requisite   pam_deny.so
 
 ## linuxmuster-linuxclient7: mount the homedir first using requisite
-session requisite   pam_mkhomedir.so  skel=@@userTemplateDir@@
+session requisite   pam_mkhomedir.so   umask=077 skel=@@userTemplateDir@@
 ## linuxmuster-linuxclient7: exec more scripts as root using requisite
 session requisite   pam_exec.so @@hookScriptLoginLogoutAsRoot@@
 


### PR DESCRIPTION
This changes the umask of userhomes to 077 (Permissions will be 700 respectively) to prevent other users from accessing their data. The default is  022 which makes it possible for users to access other users data if they know the explicit path.
See: 
- http://linux-pam.org/Linux-PAM-html/sag-pam_mkhomedir.html
- https://ask.linuxmuster.net/t/linuxclient-verzeichnisrechte/8607

@kiarn @PLanB2008 do you see any unwanted implications of this?