### PR TITLE
Fix: add missing dependency libsss-sudo

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 5.0.0
 
 Package: linuxmuster-linuxclient7
 Architecture: all
-Depends: python3, python3-ldap, cifs-utils, ldb-tools, bind9-host, ipcalc, hxtools, network-manager, krb5-user, keyutils, samba, sssd, sssd-tools, adcli, libpam-sss, sudo, realmd, cups (>= 2.3.0), coreutils
+Depends: python3, python3-ldap, cifs-utils, ldb-tools, bind9-host, ipcalc, hxtools, network-manager, krb5-user, keyutils, samba, sssd, sssd-tools, libsss-sudo, adcli, libpam-sss, sudo, realmd, cups (>= 2.3.0), coreutils
 Description: Package for Ubuntu clients to connect to the linuxmuster.net 7 active directory server.
 Conflicts: linuxmuster-client-adsso, linuxmuster-client-adsso7, ni-lmn-client-adsso


### PR DESCRIPTION
# Description

Depend on `libsss-sudo`. See: https://ask.linuxmuster.net/t/pop-os-als-linuxclient/9295

Fixes #64 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Plugin (a new plugin or an updated version of an existing plugin)
  - [ ] I agree to the [developer guidelines for plugins](https://github.com/linuxmuster/linuxmuster-linuxclient7/wiki/Plugin-developer-guidlines)
  - [ ] I will provide support and updates for this plugin
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Pop!OS 22.04
- [x] Ubuntu 22.04
- [x] Ubuntu 20.04