### PR TITLE
Fix: add libsss-sudo dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 5.0.0
 
 Package: linuxmuster-linuxclient7
 Architecture: all
-Depends: python3, python3-ldap, cifs-utils, ldb-tools, bind9-host, ipcalc, hxtools, network-manager, krb5-user, keyutils, samba, sssd, sssd-tools, adcli, libpam-sss, sudo, realmd, cups (>= 2.3.0), coreutils
+Depends: python3, python3-ldap, cifs-utils, ldb-tools, bind9-host, ipcalc, hxtools, network-manager, krb5-user, keyutils, samba, sssd, sssd-tools, adcli, libsss-sudo, libpam-sss, sudo, realmd, cups (>= 2.3.0), coreutils
 Description: Package for Ubuntu clients to connect to the linuxmuster.net 7 active directory server.
 Conflicts: linuxmuster-client-adsso, linuxmuster-client-adsso7, ni-lmn-client-adsso


### PR DESCRIPTION
# Description

Adds the `libsss-sudo` to package dependencies

Fixes #64 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Plugin (a new plugin or an updated version of an existing plugin)
  - [ ] I agree to the [developer guidelines for plugins](https://github.com/linuxmuster/linuxmuster-linuxclient7/wiki/Plugin-developer-guidlines)
  - [ ] I will provide support and updates for this plugin
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] On a Ubuntu 20.04 client
- [ ] On a Pop!OS 22.04 client

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules